### PR TITLE
Use a spinner component when the image URL is not ready

### DIFF
--- a/src/components/ImageControl/index.js
+++ b/src/components/ImageControl/index.js
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
-import { BaseControl, Button } from '@wordpress/components';
+import { BaseControl, Button, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -49,11 +49,11 @@ export default function ImageControl( props ) {
 					allowedTypes={ allowedTypes }
 					render={ ( { open } ) => (
 						<div>
-							{ imageUrl && (
+							{ imageUrl ? (
 								<Button isLink onClick={ open }>
 									<img alt="" src={ imageUrl } />
 								</Button>
-							) }
+							) : <Spinner /> }
 							<Button isSecondary onClick={ open }>
 								{ value ? replaceButtonText : buttonText }
 							</Button>


### PR DESCRIPTION
Gives users immediate feedback when setting an image if it hasn't loaded in yet/editor is still fetching from the media endpoint