### PR TITLE
Publish GitHub action

### DIFF
--- a/.github/actions/publish-to-npm/action.yml
+++ b/.github/actions/publish-to-npm/action.yml
@@ -1,0 +1,18 @@
+name: Publish to npm
+on:
+  push:
+    tags:
+      - v*.*.*
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+        with:
+          cache_version: ${{ secrets.GH_ACTIONS_CACHE_KEY }}
+      - run: npm install
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,6 @@ Human Made - Block Editor Components - Contribution Guide
 * Open a pull request against [`humanmade/block-editor-components`](https://github.com/humanmade/block-editor-components)
 * Pull requests should be reviewed and merged by an engineer at Human Made.
 
-## Releasing a new version.
-
-* Check out `main` locally and check you are synced with origin. `git checkout main & git reset origin/main --hard`
-* Run `npm version major|minor|patch`, adjusting as necessary depending on the type of release.
-* `git push -u origin/new-release --tags`
-
 ## Local development.
 
 You can contribute to this project whilst working on a project that is using it by using [npm link](https://docs.npmjs.com/cli/v8/commands/npm-link).
@@ -42,3 +36,7 @@ When you're done, you can unlink the package by running the following:
 ```
 npm unlink @humanmade/block-editor-components
 ```
+
+### Automatically build after making changes.
+
+Whilst developing, it is useful have webpack watch for changes and rebuild the distributed files automatically. To do this, run `npm run start`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+Human Made - Block Editor Components - Contribution Guide
+=========================================================
+
+* Create a feature branch from `main`.
+* Work on your change locally.
+* Open a pull request against [`humanmade/block-editor-components`](https://github.com/humanmade/block-editor-components)
+* Pull requests should be reviewed and merged by an engineer at Human Made.
+
+## Releasing a new version.
+
+* Check out `main` locally and check you are synced with origin. `git checkout main & git reset origin/main --hard`
+* Run `npm version major|minor|patch`, adjusting as necessary depending on the type of release.
+* `git push -u origin/new-release --tags`
+
+## Local development.
+
+You can contribute to this project whilst working on a project that is using it by using [npm link](https://docs.npmjs.com/cli/v8/commands/npm-link).
+
+Setting this up is a 2 part process. First, clone a copy of block editor components and link it locally.
+
+```bash
+# Clone this repo into a new directory (completely separate from any project.)
+git clone git@github.com:humanmade/block-editor-components.git
+# Change to the block editor components directory.
+cd block-editor-components
+# Install dependencies and build.
+npm install && npm run build
+# Link this package.
+npm link
+```
+
+Next,  from your project root directory, run:
+
+```bash
+npm link @humanmade/block-editor-components
+```
+
+Now, your project will use a version of `block-editor-components` that is symlinked from the repo you just cloned. You can check out a new feature branch, work on a change, test it within a real project,
+
+When you're done, you can unlink the package by running the following:
+
+```
+npm unlink @humanmade/block-editor-components
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,13 @@ Human Made - Block Editor Components - Contribution Guide
 * Open a pull request against [`humanmade/block-editor-components`](https://github.com/humanmade/block-editor-components)
 * Pull requests should be reviewed and merged by an engineer at Human Made.
 
+## Releasing a new version.
+
+* Check out `main` locally and check you are synced with origin. `git checkout main & git reset origin/main --hard`
+* Run `npm version major|minor|patch`, adjusting as necessary depending on the type of release.
+* `git push -u origin/new-release --tags`
+* Once the new tag is shared, a github action will build and publish to npm automatically.
+
 ## Local development.
 
 You can contribute to this project whilst working on a project that is using it by using [npm link](https://docs.npmjs.com/cli/v8/commands/npm-link).

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	"repository": "github:humanmade/block-editor-components",
 	"scripts": {
 		"build": "webpack",
+		"start": "webpack watch --mode development",
 		"lint": "eslint .",
 		"test": "jest"
 	},


### PR DESCRIPTION
It would be neat to publish automatically when a new version is tagged. 

One reason for this is that any engineer at Human Made could tag a new release without being added to our npm organisation. 

I'm not 100% sure of the exact workflow we would like around this. e.g. bumping the version, and pushing the tags. So maybe the instructions around this need a bit of refinement. 

NOTE: I've not actually tested this... not totally sure how to do so. I'm not super familiar with github actions. 