### PR TITLE
Audit and update packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,12 +66,13 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-			"integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.22.5"
+				"@babel/highlight": "^7.23.4",
+				"chalk": "^2.4.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -144,12 +145,12 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-			"integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+			"integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.22.5",
+				"@babel/types": "^7.23.6",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -258,22 +259,22 @@
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-			"integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-			"integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.22.5",
-				"@babel/types": "^7.22.5"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -426,18 +427,18 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-			"integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -481,13 +482,13 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-			"integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.5",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"engines": {
@@ -495,9 +496,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.22.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-			"integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+			"integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -2051,34 +2052,34 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-			"integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+			"integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.22.5",
-				"@babel/parser": "^7.22.5",
-				"@babel/types": "^7.22.5"
+				"@babel/code-frame": "^7.23.5",
+				"@babel/parser": "^7.23.9",
+				"@babel/types": "^7.23.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.22.8",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-			"integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
+			"integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.22.5",
-				"@babel/generator": "^7.22.7",
-				"@babel/helper-environment-visitor": "^7.22.5",
-				"@babel/helper-function-name": "^7.22.5",
+				"@babel/code-frame": "^7.23.5",
+				"@babel/generator": "^7.23.6",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.22.7",
-				"@babel/types": "^7.22.5",
-				"debug": "^4.1.0",
+				"@babel/parser": "^7.23.9",
+				"@babel/types": "^7.23.9",
+				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -2086,13 +2087,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-			"integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+			"integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.22.5",
-				"@babel/helper-validator-identifier": "^7.22.5",
+				"@babel/helper-string-parser": "^7.23.4",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -11917,12 +11918,13 @@
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-			"integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.22.5"
+				"@babel/highlight": "^7.23.4",
+				"chalk": "^2.4.2"
 			}
 		},
 		"@babel/compat-data": {
@@ -11974,12 +11976,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-			"integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+			"integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.22.5",
+				"@babel/types": "^7.23.6",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -12058,19 +12060,19 @@
 			}
 		},
 		"@babel/helper-environment-visitor": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-			"integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
 			"dev": true
 		},
 		"@babel/helper-function-name": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-			"integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.22.5",
-				"@babel/types": "^7.22.5"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
@@ -12178,15 +12180,15 @@
 			}
 		},
 		"@babel/helper-string-parser": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
 			"dev": true
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-			"integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
@@ -12218,20 +12220,20 @@
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-			"integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.22.5",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.22.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-			"integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+			"integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
 			"dev": true
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -13261,42 +13263,42 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-			"integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+			"integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.22.5",
-				"@babel/parser": "^7.22.5",
-				"@babel/types": "^7.22.5"
+				"@babel/code-frame": "^7.23.5",
+				"@babel/parser": "^7.23.9",
+				"@babel/types": "^7.23.9"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.22.8",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-			"integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
+			"integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.22.5",
-				"@babel/generator": "^7.22.7",
-				"@babel/helper-environment-visitor": "^7.22.5",
-				"@babel/helper-function-name": "^7.22.5",
+				"@babel/code-frame": "^7.23.5",
+				"@babel/generator": "^7.23.6",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.22.7",
-				"@babel/types": "^7.22.5",
-				"debug": "^4.1.0",
+				"@babel/parser": "^7.23.9",
+				"@babel/types": "^7.23.9",
+				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-			"integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+			"integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-string-parser": "^7.22.5",
-				"@babel/helper-validator-identifier": "^7.22.5",
+				"@babel/helper-string-parser": "^7.23.4",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			}
 		},


### PR DESCRIPTION
A quick update, using `npm audit fix` due to an alert when installing:

- Update @babel/code-frame [7.22.5 => 7.23.5]
- Update @babel/generator [7.22.9 => 7.23.6]
- Update @babel/helper-environment-visitor [7.22.5 => 7.22.20]
- Update @babel/helper-function-name [7.22.5 => 7.23.0]
- Update @babel/helper-string-parser [7.22.5 => 7.23.4]
- Update @babel/helper-validator-identifier [7.22.5 => 7.22.20]
- Update @babel/highlight [7.22.5 => 7.23.4]
- Update @babel/parser [7.22.7 => 7.23.9]
- Update @babel/template [7.22.5 => 7.23.9]
- Update @babel/traverse [7.22.8 => 7.23.9]
- Update @babel/types [7.22.5 => 7.23.9]