### PR TITLE
262 Remove asset build from release, update entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.log
 /.idea/
 /.vscode/
-/dist/index.asset.php
+/dist/
 /node_modules/
 /vendor/
 /dist/

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@
 /.nvmrc
 /babel.config.js
 /webpack.config.js
+/dist/

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"name": "Human Made",
 		"url": "https://humanmade.com"
 	},
-	"main": "dist/index.js",
+	"main": "src/index.js",
 	"repository": "github:humanmade/block-editor-components",
 	"scripts": {
 		"build": "webpack",


### PR DESCRIPTION
Resolves #262 

Remove the build assets from npm releases, and update the `main` field in package.json to keep imports working the same.