### PR TITLE
Pass context to postPicker query args

### DIFF
--- a/src/components/PostPicker/index.js
+++ b/src/components/PostPicker/index.js
@@ -198,6 +198,7 @@ function BrowsePanel( props ) {
 		search: search || undefined, // When empty, set as undefined to omit query var from API request.
 		per_page: 30,
 		...taxQueries,
+		context: 'view',
 	};
 
 	return (


### PR DESCRIPTION
This fixes a bug on certain WordPress versions:

When passing queryArgs to getEntityRecords for posts, the request will return no results unless the `context` argument is explicitly set.

Note that `view` should be the default for this request anyway, so the results returned should not change.

https://developer.wordpress.org/rest-api/reference/posts/#definition 