### PR TITLE
Use peerdeps for dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
 			"name": "@humanmade/block-editor-components",
 			"version": "0.7.0",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"classnames": "^2.3.2"
-			},
 			"devDependencies": {
 				"@babel/plugin-proposal-class-properties": "^7.18.6",
 				"@babel/plugin-proposal-private-property-in-object": "^7.21.11",
@@ -23,6 +20,7 @@
 				"babel-eslint": "^10.1.0",
 				"babel-jest": "^29.5.0",
 				"babel-loader": "^8.3.0",
+				"classnames": "^2.5.1",
 				"eslint": "^8.37.0",
 				"eslint-config-react-app": "^7.0.1",
 				"eslint-plugin-flowtype": "^8.0.3",
@@ -5151,7 +5149,8 @@
 		"node_modules/classnames": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-			"integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+			"integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+			"dev": true
 		},
 		"node_modules/clipboard": {
 			"version": "2.0.11",
@@ -15974,7 +15973,8 @@
 		"classnames": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-			"integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+			"integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+			"dev": true
 		},
 		"clipboard": {
 			"version": "2.0.11",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"babel-eslint": "^10.1.0",
 		"babel-jest": "^29.5.0",
 		"babel-loader": "^8.3.0",
+		"classnames": "^2.5.1",
 		"eslint": "^8.37.0",
 		"eslint-config-react-app": "^7.0.1",
 		"eslint-plugin-flowtype": "^8.0.3",
@@ -51,13 +52,14 @@
 		"webpack": "^5.77.0",
 		"webpack-cli": "^4.10.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.2",
+		"classnames": "^2.5.1"
+	},
 	"engines": {
 		"node": ">=16"
 	},
 	"publishConfig": {
 		"access": "public"
-	},
-	"dependencies": {
-		"classnames": "^2.3.2"
 	}
 }


### PR DESCRIPTION
Reviewing our dependencies, I noticed that `classnames` is listed as a dependency. I don't think this is necessary as we ship the built files. 

However if you wish to import the source files... I think specifying the peerDeps will ensure that you know what's needed in order to incorporate them in your project