### PR TITLE
Inner block slider pages

### DIFF
--- a/src/components/InnerBlockSlider/README.md
+++ b/src/components/InnerBlockSlider/README.md
@@ -104,6 +104,7 @@ The above example code creates a slider using the core image block as each slide
 | `slideLimit`     | `integer`      | `10`    | Maximum number of slides.                     |
 | `parentBlockId`  | `string`       | `''`    | Client ID of parent block. This is required.  |
 | `showNavigation` | `bool`         | `true`  | Whether to show slide navigation/pagination.  |
+| `perPage`        | `integer`      | `1`     | Show multiple slides per page.                |
 
 ## Examples
 

--- a/src/components/InnerBlockSlider/inner-block-single-display.js
+++ b/src/components/InnerBlockSlider/inner-block-single-display.js
@@ -44,6 +44,13 @@ function InnerBlocksDisplaySingle( {
 		}
 	);
 
+	/**
+	 * Construct the CSS for this component.
+	 *
+	 * Hide all slides except the current active slide.
+	 * Account for pages - show current slide + perPage slides.
+	 * Display grid if perPage > 1.
+	 */
 	useEffect( () => {
 		if ( ! styleRef.current ) {
 			return;

--- a/src/components/InnerBlockSlider/inner-block-single-display.js
+++ b/src/components/InnerBlockSlider/inner-block-single-display.js
@@ -14,16 +14,18 @@ import { useInnerBlocksProps } from '@wordpress/block-editor';
  * @param {boolean}                 props.className        Class name.
  * @param {boolean|React.ReactNode} props.renderAppender   Appender.
  * @param {boolean}                 props.captureToolbars  Passed through to inner block props.
+ * @param {number}                  props.perPage          Number of items to display per page.
  * @returns {React.ReactNode} Component.
  */
 function InnerBlocksDisplaySingle( {
 	className,
 	allowedBlocks,
 	template,
-	currentItemIndex,
+	currentItemIndex = 0,
 	parentBlockId,
-	renderAppender,
-	captureToolbars,
+	renderAppender = false,
+	captureToolbars = true,
+	perPage = 1,
 } ) {
 	const styleRef = useRef();
 
@@ -47,10 +49,23 @@ function InnerBlocksDisplaySingle( {
 			return;
 		}
 
-		styleRef.current.innerHTML = `#inner-block-display-single-${ parentBlockId } > *:not(:nth-child(${
-			currentItemIndex + 1
-		}) ) { display: none; }`;
-	}, [ currentItemIndex, styleRef, parentBlockId ] );
+		const containerSelector = `#inner-block-display-single-${ parentBlockId }`;
+
+		let style = '';
+
+		if ( perPage > 1 ) {
+			style += `${containerSelector} { display: grid; grid-template-columns: repeat(${ perPage }, 1fr); }`;
+		}
+
+		style += `${containerSelector} > *:not(`;
+		for ( let i = 1; i <= perPage; i++ ) {
+			style += `:nth-child(${ currentItemIndex + i }), `;
+		}
+		style = style.slice( 0, -2 ) + ')';
+		style += '{ display: none; }';
+
+		styleRef.current.innerHTML = `${style}`;
+	}, [ currentItemIndex, styleRef, parentBlockId, perPage ]);
 
 	return (
 		<>
@@ -59,12 +74,6 @@ function InnerBlocksDisplaySingle( {
 		</>
 	);
 }
-
-InnerBlocksDisplaySingle.defaultProps = {
-	currentItemIndex: 0,
-	renderAppender: false,
-	captureToolbars: true,
-};
 
 InnerBlocksDisplaySingle.propTypes = {
 	parentBlockId: PropTypes.string.isRequired,
@@ -76,6 +85,7 @@ InnerBlocksDisplaySingle.propTypes = {
 		PropTypes.bool,
 		PropTypes.element,
 	] ),
+	perPage: PropTypes.number,
 };
 
 export default InnerBlocksDisplaySingle;

--- a/src/components/InnerBlockSlider/inner-block-single-display.js
+++ b/src/components/InnerBlockSlider/inner-block-single-display.js
@@ -68,7 +68,7 @@ function InnerBlocksDisplaySingle( {
 		for ( let i = 1; i <= perPage; i++ ) {
 			style += `:nth-child(${ currentItemIndex + i }), `;
 		}
-		style = style.slice( 0, -2 ) + ')';
+		style = style.slice( 0, -2 ) + ')'; // Slice to remove trailing comma and space.
 		style += '{ display: none; }';
 
 		styleRef.current.innerHTML = `${style}`;

--- a/src/components/InnerBlockSlider/inner-block-single-display.js
+++ b/src/components/InnerBlockSlider/inner-block-single-display.js
@@ -54,7 +54,7 @@ function InnerBlocksDisplaySingle( {
 		let style = '';
 
 		if ( perPage > 1 ) {
-			style += `${containerSelector} { display: grid; grid-template-columns: repeat(${ perPage }, 1fr); }`;
+			style += `${containerSelector} { display: grid; grid-template-columns: repeat(${ perPage }, 1fr); gap: 1em; }`;
 		}
 
 		style += `${containerSelector} > *:not(`;
@@ -65,7 +65,7 @@ function InnerBlocksDisplaySingle( {
 		style += '{ display: none; }';
 
 		styleRef.current.innerHTML = `${style}`;
-	}, [ currentItemIndex, styleRef, parentBlockId, perPage ]);
+	}, [ currentItemIndex, styleRef, parentBlockId, perPage ] );
 
 	return (
 		<>

--- a/src/components/InnerBlockSlider/inner-block-slider-controlled.js
+++ b/src/components/InnerBlockSlider/inner-block-slider-controlled.js
@@ -106,8 +106,8 @@ const InnerBlockSliderControlled = ( {
 				className="slides"
 				currentItemIndex={ currentItemIndex }
 				parentBlockId={ parentBlockId }
-				template={ innerBlockTemplate }
 				perPage={ perPage }
+				template={ innerBlockTemplate }
 			/>
 
 			{ showNavigation && (

--- a/src/components/InnerBlockSlider/inner-block-slider-controlled.js
+++ b/src/components/InnerBlockSlider/inner-block-slider-controlled.js
@@ -10,24 +10,26 @@ import Navigation from './navigation';
 /**
  * InnerBlockSlider component.
  *
- * @param {object} props                       Component props.
- * @param {string} props.parentBlockId         Parent block clientId.
- * @param {string} props.allowedBlock          Allowed block type.
- * @param {Array}  props.template              Initial block template.
- * @param {number} props.slideLimit            Maximum allowed slides.
- * @param {number} props.currentItemIndex      Override current index, if managing this externally.
+ * @param {object}   props                     Component props.
+ * @param {string}   props.parentBlockId       Parent block clientId.
+ * @param {string}   props.allowedBlock        Allowed block type.
+ * @param {Array}    props.template            Initial block template.
+ * @param {number}   props.slideLimit          Maximum allowed slides.
+ * @param {number}   props.currentItemIndex    Override current index, if managing this externally.
  * @param {Function} props.setCurrentItemIndex Override set item Index
  * @param {Function} props.showNavigation      Override display nav
+ * @param {number}   props.perPage             Number of items to display per page.
  * @returns {React.ReactNode} Component.
  */
 const InnerBlockSliderControlled = ( {
 	parentBlockId,
 	allowedBlock,
 	template,
-	slideLimit,
+	slideLimit = 10,
 	currentItemIndex,
 	setCurrentItemIndex,
-	showNavigation,
+	showNavigation = true,
+	perPage = 1,
 } ) => {
 	const innerBlockTemplate = template || [ [ allowedBlock ] ];
 
@@ -105,6 +107,7 @@ const InnerBlockSliderControlled = ( {
 				currentItemIndex={ currentItemIndex }
 				parentBlockId={ parentBlockId }
 				template={ innerBlockTemplate }
+				perPage={ perPage }
 			/>
 
 			{ showNavigation && (
@@ -122,12 +125,6 @@ const InnerBlockSliderControlled = ( {
 				/> ) }
 		</div>
 	);
-};
-
-InnerBlockSliderControlled.defaultProps = {
-	slideLimit: 10,
-	template: null,
-	showNavigation: true,
 };
 
 InnerBlockSliderControlled.propTypes = {


### PR DESCRIPTION
I've built a carousel plugin on top of this, and one of the features we need to display is showing multiple slides per page. 

e.g

<img width="843" alt="image" src="https://github.com/user-attachments/assets/638a15ea-090f-499f-ab81-443d186cb2eb" />


This PR adds support for previewing this type of layout in the innerBlockSlider plugin

Here it is in action: 

<img width="774" alt="image" src="https://github.com/user-attachments/assets/6f82d9fc-93db-4e4e-b7a5-149f90972aba" />

Also fixed here - remove default props and use default values in JS object - use of defaultProps is deprecated. 
